### PR TITLE
Issue when EnableClientScript is false

### DIFF
--- a/AjaxControlToolkit/MaskedEdit/MaskedEditValidator.cs
+++ b/AjaxControlToolkit/MaskedEdit/MaskedEditValidator.cs
@@ -715,7 +715,7 @@ namespace AjaxControlToolkit {
                         base.Text = InvalidValueBlurredMessage;
                 }
             }
-            if(!ok) {
+            if(!ok && EnableClientScript) {
                 // set CSS at server for browser with not implement client validator script (FF, others)   
                 //MaskedEditSetCssClass(value,CSS)
                 var script = "MaskedEditSetCssClass(" + ClientID + ",'" + cssError + "');";


### PR DESCRIPTION
issue when EnableClientScript is false TargetValidator not is loaded anthen throw a exception on client explorer.